### PR TITLE
update workflow for publish CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,17 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+  release:
+    types: [published]
+
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Python package
 on: [push]
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,3 +23,30 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
+
+  build-and-publish:
+    needs: tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release'}}
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Build package
+      run: |
+        python -m pip install --upgrade build
+        python -m build
+
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{secrets.PYPI_API_KEY}}
+      run: |
+        python -m pip install --upgrade twine
+        python3 -m twine upload dist/*


### PR DESCRIPTION
Added publish automation on new release in the workflow file
- Need to create a new release manually after everything is updated and set to be published.
- Same version fails the workflow run, version update is necessary.
- Publish Job doesn't execute if the event is not release.
- Tests Run on both events push as well as release.
- Deployment Documentation: [Python SDK Deployment](https://www.notion.so/brine-fi/Python-SDK-Deployment-0cb2f536f1c240feb177c7df522e8d9b?pvs=4)